### PR TITLE
fix: don't override configs when no wallet import beforehand

### DIFF
--- a/backend/src/controllers/tools.ts
+++ b/backend/src/controllers/tools.ts
@@ -127,7 +127,7 @@ export const saveUserConfig = async (req: Request, res: Response) => {
     const existingContentString = await streamToString(
       existingData.Body as NodeJS.ReadableStream
     )
-    let existingConfig: ConfigVersions = JSON.parse(existingContentString)
+    const existingConfig: ConfigVersions = JSON.parse(existingContentString)
 
     // parse and sanitize new config data
     const newConfigData: ConfigVersions = JSON.parse(data?.fullconfig)

--- a/frontend/app/routes/create.$type.tsx
+++ b/frontend/app/routes/create.$type.tsx
@@ -274,7 +274,10 @@ export default function Create() {
   useEffect(() => {
     // ensure fullconfig always has the current version's data, even for 'default'
     // with no wa import beforehand
-    if (fullConfig || (selectedVersion === 'default' && toolConfig.walletAddress)) {
+    if (
+      fullConfig ||
+      (selectedVersion === 'default' && toolConfig.walletAddress)
+    ) {
       const updatedFullConfig = {
         ...fullConfig,
         [selectedVersion]: toolConfig

--- a/frontend/app/routes/create.$type.tsx
+++ b/frontend/app/routes/create.$type.tsx
@@ -272,7 +272,8 @@ export default function Create() {
   }, [response])
 
   useEffect(() => {
-    if (fullConfig) {
+    // ensure fullconfig always has the current version's data, even for 'default
+    if (fullConfig || selectedVersion === 'default') {
       const updatedFullConfig = {
         ...fullConfig,
         [selectedVersion]: toolConfig

--- a/frontend/app/routes/create.$type.tsx
+++ b/frontend/app/routes/create.$type.tsx
@@ -272,8 +272,9 @@ export default function Create() {
   }, [response])
 
   useEffect(() => {
-    // ensure fullconfig always has the current version's data, even for 'default
-    if (fullConfig || selectedVersion === 'default') {
+    // ensure fullconfig always has the current version's data, even for 'default'
+    // with no wa import beforehand
+    if (fullConfig || (selectedVersion === 'default' && toolConfig.walletAddress)) {
       const updatedFullConfig = {
         ...fullConfig,
         [selectedVersion]: toolConfig


### PR DESCRIPTION
### Proposed changes

Key changes made:

-  added retrieval of existing config from S3 before making changes
-  only update the specific keys that are present in the new config
-  maintain existing config data for keys not included in the update
-  handle case where no existing config exists yet

This way sanizitation still happens on all updated fields and other existing versions will be preserved in S3 when no importing of an wallet address was done beforehand
