### PR TITLE
fix(ui/TypeCard): bottom align "Generate" buttons

### DIFF
--- a/frontend/app/components/TypeCard.tsx
+++ b/frontend/app/components/TypeCard.tsx
@@ -32,7 +32,9 @@ export const TypeCard = ({
         <span>{title}</span>
         <InfoWithTooltip tooltip={tooltip} />
       </span>
-      <p className="text-center text-sm min-h-36 p-4 mb-4">{description}</p>
+      <p className="text-center text-sm min-h-36 p-4 mb-4 h-full">
+        {description}
+      </p>
       <Button intent="default" aria-label={title} to={link} target={'_parent'}>
         Generate
       </Button>


### PR DESCRIPTION
This aligns the button on `TypeCard` to the bottom, so that when multiple cards are used the buttons are all in the same place.

Before:

![Screen Shot 2025-03-24 at 11 56 34](https://github.com/user-attachments/assets/651a8b26-9712-4dc9-9baa-7f01a684bfb8)

With this PR:

![Screen Shot 2025-03-24 at 11 58 07](https://github.com/user-attachments/assets/ea9ebc66-bc13-4395-9088-32f4615b5592)
